### PR TITLE
Reinsert mistakenly deleted word in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ simply by defining conformance to the `WebSock` behaviour, in the same manner as
 how Plug conformance allows their HTTP aspects to be hosted within an arbitrary
 web server.
 
-This package defines the `WebSock` which describes the functions that an
-application such as Phoenix must implement in order to be WebSock compliant; it
+This package defines the `WebSock` behaviour which describes the functions that
+an application such as Phoenix must implement in order to be WebSock compliant; it
 is roughly the equivalent of the `Plug` interface, but for WebSocket
 connections. It is commonly used in conjunction with the
 [websock_adapter](https://hex.pm/packages/websock_adapter) package which


### PR DESCRIPTION
There was a previous commit that aimed to fix a typo, but it introduced another one at the same time instead.
If the word "behaviour" was purposely removed, than the word "the" that preceded `WebSock` should be removed instead.