### PR TITLE
Make terminate/2 optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ and `WebSock.Adapters`:
   whenever other processes send messages to the handler process
 * The `WebSock` implementation can send data to the client by returning
   a `{:push,...}` tuple from any of the above `handle_*` callbacks
-* At any time, `c:WebSock.terminate/2` may be called to indicate a close, error or
+* At any time, `c:WebSock.terminate/2` (if implemented) may be called to indicate a close, error or
   timeout condition
 
 For more information, consult the [docs](https://hexdocs.pm/websock).

--- a/lib/websock.ex
+++ b/lib/websock.ex
@@ -145,9 +145,11 @@ defmodule WebSock do
     handling in the local server, or the result of a `WebSock.handle_*` callback returning a `{:stop,
     reason, state}` tuple where reason is any value other than `:normal`
 
+  This callback is optional
+
   The return value of this callback is ignored
   """
   @callback terminate(reason :: close_reason(), state()) :: any()
 
-  @optional_callbacks handle_control: 2
+  @optional_callbacks handle_control: 2, terminate: 2
 end


### PR DESCRIPTION
By popular request, terminate should be optional. Mandatory callbacks include `init/2`, `handle_info/2` and `handle_in/2` to keep rough parity with similar semantics on GenServer