### PR TITLE
Add draining contract

### DIFF
--- a/lib/websock.ex
+++ b/lib/websock.ex
@@ -57,7 +57,7 @@ defmodule WebSock do
           {:push, {opcode(), message()} | [{opcode(), message()}], state()}
           | {:reply, term(), {opcode(), message()} | [{opcode(), message()}], state()}
           | {:ok, state()}
-          | {:stop, {:shutdown, :draining} | term(), state()}
+          | {:stop, {:shutdown, :restart} | term(), state()}
           | {:stop, term(), close_detail(), state()}
 
   @typedoc "Details about why a connection was closed"

--- a/lib/websock.ex
+++ b/lib/websock.ex
@@ -57,7 +57,7 @@ defmodule WebSock do
           {:push, {opcode(), message()} | [{opcode(), message()}], state()}
           | {:reply, term(), {opcode(), message()} | [{opcode(), message()}], state()}
           | {:ok, state()}
-          | {:stop, term(), state()}
+          | {:stop, {:shutdown, :draining} | term(), state()}
           | {:stop, term(), close_detail(), state()}
 
   @typedoc "Details about why a connection was closed"
@@ -101,7 +101,9 @@ defmodule WebSock do
   * `{:ok, state()}`: The indicated state value is used to update the socket's current state
   * `{:stop, reason :: term(), state()}`: The connection will be closed based on the indicated
     reason. If `reason` is `:normal`, `c:terminate/2` will be called with a `reason` value of
-    `:normal`. In all other cases, it will be called with `{:error, reason}`. Server
+    `:normal`. If the `reason` is `{:shutdown, :draining}`, the server is draining connections and
+    the WebSocket adapter should close with the `1012` Service Restart code.
+    In all other cases, it will be called with `{:error, reason}`. Server
     implementations should also use this value when determining how to close the connection with
     the client
   * `{:stop, reason :: term(), close_detail(), state()}`: Similar to the previous clause, but allows

--- a/lib/websock.ex
+++ b/lib/websock.ex
@@ -101,7 +101,7 @@ defmodule WebSock do
   * `{:ok, state()}`: The indicated state value is used to update the socket's current state
   * `{:stop, reason :: term(), state()}`: The connection will be closed based on the indicated
     reason. If `reason` is `:normal`, `c:terminate/2` will be called with a `reason` value of
-    `:normal`. If the `reason` is `{:shutdown, :draining}`, the server is draining connections and
+    `:normal`. If the `reason` is `{:shutdown, :restart}`, the server is restarting and
     the WebSocket adapter should close with the `1012` Service Restart code.
     In all other cases, it will be called with `{:error, reason}`. Server
     implementations should also use this value when determining how to close the connection with


### PR DESCRIPTION
Phoenix.Socket returns `{:socket, :draining}` when phoenix is draining connections. Supporting this inside websock allows us to keep the socket transport agnostic. Companion PR will be opened on websock_adapter